### PR TITLE
fix: Force use of locally-built images, specify container registry otherwise

### DIFF
--- a/Docker/run/compose/sharded.example.yml
+++ b/Docker/run/compose/sharded.example.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:latest
+    image: docker.io/postgres:latest
     restart: always
     environment:
       POSTGRES_DB: "${LACI_POSTGRES_DB}"
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   haproxy:
-    image: haproxy:latest
+    image: docker.io/haproxy:latest
     restart: always
     ports: 
       - 6000:6000/tcp
@@ -28,13 +28,14 @@ services:
         condition: service_healthy
         
   redis:
-    image: redis:latest
+    image: docker.io/redis:latest
     command: [sh, -c, "rm -f /data/dump.rdb && redis-server --save \"\" --appendonly no --requirepass $${LACI_REDIS_PASSWORD}"]
     volumes:
       - cache:/data
 
   laci-server:
-    image: ghcr.io/lacisynchroni/server:latest
+    image: lacisynchroni/server:latest
+    pull_policy: never
     restart: on-failure
     environment:
       LaciSynchroni__CdnFullUrl: "${LACI_CDNURL}"
@@ -52,7 +53,8 @@ services:
       timeout: 1s
 
   laci-shard-1:
-    image: ghcr.io/lacisynchroni/server:latest
+    image: lacisynchroni/server:latest
+    pull_policy: never
     restart: on-failure
     volumes:
       - ../config/sharded/server-shard-1.json:/opt/LaciSynchroni/Server/appsettings.json
@@ -63,7 +65,8 @@ services:
         condition: service_healthy
 
   laci-shard-2:
-    image: ghcr.io/lacisynchroni/server:latest
+    image: lacisynchroni/server:latest
+    pull_policy: never
     restart: on-failure
     volumes:
       - ../config/sharded/server-shard-2.json:/opt/LaciSynchroni/Server/appsettings.json
@@ -74,7 +77,8 @@ services:
         condition: service_healthy
 
   laci-services:
-    image: ghcr.io/lacisynchroni/services:latest
+    image: lacisynchroni/services:latest
+    pull_policy: never
     restart: on-failure
     volumes:
       - ../config/standalone/services-standalone.json:/opt/LaciSynchroni/Services/appsettings.json
@@ -85,7 +89,8 @@ services:
         condition: service_healthy
 
   laci-files:
-    image: ghcr.io/lacisynchroni/staticfilesserver:latest
+    image: lacisynchroni/staticfilesserver:latest
+    pull_policy: never
     restart: on-failure
     ports:
       - 6200:6200/tcp
@@ -109,7 +114,8 @@ services:
       timeout: 1s
 
   laci-files-shard-1:
-    image: ghcr.io/lacisynchroni/staticfilesserver:latest
+    image: lacisynchroni/staticfilesserver:latest
+    pull_policy: never
     restart: on-failure
     volumes:
       - ../config/sharded/files-shard-1.json:/opt/LaciSynchroni/StaticFilesServer/appsettings.json
@@ -123,7 +129,8 @@ services:
         condition: service_healthy
 
   laci-files-shard-2:
-    image: ghcr.io/lacisynchroni/staticfilesserver:latest
+    image: lacisynchroni/staticfilesserver:latest
+    pull_policy: never
     restart: on-failure
     volumes:
       - ../config/sharded/files-shard-2.json:/opt/LaciSynchroni/StaticFilesServer/appsettings.json

--- a/Docker/run/compose/standalone.example.yml
+++ b/Docker/run/compose/standalone.example.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:latest
+    image: docker.io/postgres:latest
     command: ["postgres", "-c", "log_statement=all"]
     restart: always
     environment:
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   redis:
-    image: redis:latest
+    image: docker.io/redis:latest
     env_file:
       - path: ./.env.local
         required: true
@@ -25,7 +25,8 @@ services:
       - cache:/data
 
   laci-server:
-    image: ghcr.io/lacisynchroni/server:latest
+    image: lacisynchroni/server:latest
+    pull_policy: never
     restart: on-failure
     environment:
       LaciSynchroni__CdnFullUrl: "${LACI_CDNURL}"
@@ -48,7 +49,8 @@ services:
       timeout: 1s
 
   laci-services:
-    image: ghcr.io/lacisynchroni/services:latest
+    image: lacisynchroni/services:latest
+    pull_policy: never
     restart: on-failure
     environment:
       LaciSynchroni__DiscordBotToken: "${LACI_DISCORD_TOKEN}"
@@ -68,7 +70,8 @@ services:
         condition: service_healthy
 
   laci-auth:
-    image: ghcr.io/lacisynchroni/authservice:latest
+    image: lacisynchroni/authservice:latest
+    pull_policy: never
     restart: on-failure
     environment:
       LaciSynchroni__PublicOAuthBaseUri: "${LACI_PUBLIC_OAUTH_BASE_URI}"
@@ -90,7 +93,8 @@ services:
         condition: service_healthy
 
   laci-files:
-    image: ghcr.io/lacisynchroni/staticfilesserver:latest
+    image: lacisynchroni/staticfilesserver:latest
+    pull_policy: never
     restart: on-failure
     environment:
       LaciSynchroni__CdnFullUrl: "${LACI_CDNURL}"
@@ -111,7 +115,7 @@ services:
         condition: service_healthy
 
   prometheus:
-    image: prom/prometheus:latest
+    image: docker.io/prom/prometheus:latest
     restart: unless-stopped
     volumes:
       - prometheus:/prometheus
@@ -119,7 +123,7 @@ services:
     user: "1000:1000"
 
   grafana:
-    image: grafana/grafana:latest
+    image: docker.io/grafana/grafana:latest
     restart: unless-stopped
     environment:
       GF_SECURITY_ADMIN_USER: "${LACI_GF_SECURITY_ADMIN_USER}"
@@ -131,7 +135,7 @@ services:
     user: "1000:1000"
 
   cloudflared:
-    image: cloudflare/cloudflared:latest
+    image: docker.io/cloudflare/cloudflared:latest
     restart: unless-stopped
     command: tunnel run
     environment:


### PR DESCRIPTION
Current setup instructions ask hosters to build images that are then not used, because the current compose files pull them from GHCR. Additionally, the latest GHCR images are still using the old name.